### PR TITLE
FP-693: footer legal menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ export default {
 - [Button](./docs/api/button.md)
 - [Footer Menu](./docs/api/footerMenu.md)
 - [Language Switcher](./docs/api/languageSwitcher.md)
+- [Legal Menu](./docs/api/legalMenu.md)
 - [Link](./docs/api/link.md)
 - [Secondary Menu](./docs/api/secondaryMenu.md)
 - [Social Menu](./docs/api/socialMenu.md)

--- a/docs/api/legalMenu.md
+++ b/docs/api/legalMenu.md
@@ -1,0 +1,59 @@
+# Legal Menu Component API
+
+The `Legal Menu` component is designed for displaying a list of links. It is used to display legal links such as Privacy Policy, Terms of Use, etc.
+
+## Import
+
+```jsx
+import { LegalMenu } from 'forcepoint-shared-components';
+```
+
+## Props
+
+The component accepts the following props for configuration:
+
+| Name    | Type                | Description                                                     |
+|---------|---------------------|-----------------------------------------------------------------|
+| `items` | `LegalMenuItem[]`  | An array of objects width the data of each link.          |
+| `menuLabel`        | `string` | The aria-label attribute for accessibility purposes             |
+| `linkComponent` | `elementType` | Specifies the link node's element type. It accepts a string for a standard HTML `a` element or a custom component. For example, in a Next.js application, you can use `next/link` as the `Component` to integrate with Next.js's routing. |
+
+## LegalMenuItem Props
+
+The `LegalMenuItem` object accepts the following props for configuration:
+
+| Name        | Type                              | Description                                                          |
+|-------------|-----------------------------------|----------------------------------------------------------------------|
+| `linkProps` | `{ [key: string]: string; }`      | Optional. Additional props to pass to the link component.           |
+| `title`     | `string`                          | The name of the social media platform.                               |
+| `url`       | `string`                          | The URL to the social media profile.                                 |
+
+## Examples
+
+```jsx
+import { LegalMenu } from 'forcepoint-shared-components';
+
+const menuItems = [
+  {
+    title: 'Terms & Conditions',
+    url: '#',
+  },
+  {
+    title: 'Legal and Privacy',
+    url: '#',
+  },
+  {
+    title: 'Manage Cookies',
+    url: '#',
+  },
+  {
+    title: '© 2024 Forcepoint',
+    url: '#',
+  },
+];
+
+<LegalMenu items={menuItems} />;
+```
+
+
+

--- a/docs/api/socialMenu.md
+++ b/docs/api/socialMenu.md
@@ -16,7 +16,7 @@ The component accepts the following props for configuration:
 |---------|---------------------|-----------------------------------------------------------------|
 | `items` | `SocialMenuItem[]`  | An array of objects describing each social media link.          |
 | `menuLabel`        | `string` | The aria-label attribute for accessibility purposes             |
-
+| `linkComponent` | `elementType` | Specifies the link node's element type. It accepts a string for a standard HTML `a` element or a custom component. For example, in a Next.js application, you can use `next/link` as the `Component` to integrate with Next.js's routing. |
 ## SocialMenuItem Props
 
 The `SocialMenuItem` object accepts the following props for configuration:

--- a/src/lib/components/02-components/menus/footer/footer-menu.tsx
+++ b/src/lib/components/02-components/menus/footer/footer-menu.tsx
@@ -13,7 +13,7 @@ export type FooterMenuProps = {
 export default function FooterMenu({
   items,
   linkComponent: LinkComponent = 'a',
-  menuLabel = 'footer-menu',
+  menuLabel = 'Footer Menu',
 }: FooterMenuProps) {
   const [activeItems, setActiveItems] = useState<{ [key: number]: boolean }>(
     {},

--- a/src/lib/components/02-components/menus/legal-menu/legal-menu.stories.tsx
+++ b/src/lib/components/02-components/menus/legal-menu/legal-menu.stories.tsx
@@ -1,0 +1,36 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import LegalMenu from './legal-menu';
+
+const menuItems = [
+  {
+    title: 'Terms & Conditions',
+    url: '#',
+  },
+  {
+    title: 'Legal and Privacy',
+    url: '#',
+  },
+  {
+    title: 'Manage Cookies',
+    url: '#',
+  },
+  {
+    title: '© 2024 Forcepoint',
+    url: '#',
+  },
+];
+
+const meta = {
+  title: 'Components/Menus/Legal Menu',
+  component: LegalMenu,
+} satisfies Meta<typeof LegalMenu>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    items: menuItems,
+    menuLabel: 'My Legal Menu',
+  },
+};

--- a/src/lib/components/02-components/menus/legal-menu/legal-menu.tsx
+++ b/src/lib/components/02-components/menus/legal-menu/legal-menu.tsx
@@ -1,0 +1,47 @@
+import { ElementType } from 'react';
+import Link from '../../../01-elements/link/link';
+
+export type LegalMenuItem = {
+  linkProps?: {
+    [key: string]: string;
+  };
+  title: string;
+  url?: string;
+};
+
+export type LegalMenuProps = {
+  items: LegalMenuItem[];
+  menuLabel?: string;
+  linkComponent?: ElementType;
+};
+
+export default function SocialMenu({
+  items,
+  menuLabel = 'Legal Menu',
+  linkComponent: LinkComponent = 'a',
+}: LegalMenuProps) {
+  const renderItem = (item: LegalMenuItem, index: number) => {
+    if (!item.url) return;
+
+    return (
+      <li key={`legal-subitem-${index}`}>
+        <Link
+          href={item.url}
+          component={LinkComponent}
+          className="text-[11px] font-normal text-grey transition-colors"
+          {...item.linkProps}
+          aria-label={item.title}
+        >
+          {item.title}
+        </Link>
+      </li>
+    );
+  };
+  return (
+    <nav aria-label={menuLabel}>
+      <ul className="flex flex-wrap items-center justify-center gap-x-sm md:justify-start">
+        {items.map(renderItem)}
+      </ul>
+    </nav>
+  );
+}

--- a/src/lib/components/02-components/menus/social-menu/social-menu.tsx
+++ b/src/lib/components/02-components/menus/social-menu/social-menu.tsx
@@ -1,3 +1,4 @@
+import { ElementType } from 'react';
 import Link from '../../../01-elements/link/link';
 import SocialMenuIcon from './social-menu-icon';
 
@@ -13,15 +14,25 @@ export type SocialMenuItem = {
 export type SocialMenuProps = {
   items: SocialMenuItem[];
   menuLabel?: string;
+  linkComponent?: ElementType;
 };
 
-export default function SocialMenu({ items, menuLabel }: SocialMenuProps) {
+export default function SocialMenu({
+  items,
+  menuLabel = 'Social Menu',
+  linkComponent: LinkComponent = 'a',
+}: SocialMenuProps) {
   const renderItem = (item: SocialMenuItem, index: number) => {
     if (!item.url) return;
 
     return (
-      <li key={`footer-subitem-${index}`}>
-        <Link href={item.url} {...item.linkProps} aria-label={item.title}>
+      <li key={`social-subitem-${index}`}>
+        <Link
+          href={item.url}
+          {...item.linkProps}
+          component={LinkComponent}
+          aria-label={item.title}
+        >
           <span className="sr-only">{item.title}</span>
           <SocialMenuIcon icon={item.icon} />
         </Link>


### PR DESCRIPTION
# Ticket(s)

- [FP-693: Footer Legal Menu](https://fourkitchens.clickup.com/t/36718269/FP-693)

## Purpose

- Creates the legalMenu component
- Adds a missing functionality to the socialMenu component to allow to send the link element type

### Functional Testing

- [x] Go to http://localhost:6006/?path=/story/components-menus-legal-menu--default
- [x] The component should match the [design](https://www.figma.com/file/HwazkcYwlIm9Yz6NwIQ1b3/Web-Standards?node-id=1562%3A2092&mode=dev) on mobile and desktop
- [x] Should be accesible 
- [x] The documentation should be clear and easy to follow

<img width="500" alt="Screenshot 2024-02-13 at 7 02 46 PM" src="https://github.com/fourkitchens/forcepoint-shared-components/assets/9342250/adb127d8-3aa2-4072-af42-f34c0dc30870">
