### PR TITLE
FP-306: Logo grid - FED

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ export default {
 - [Language Switcher](./docs/api/languageSwitcher.md)
 - [Legal Menu](./docs/api/legalMenu.md)
 - [Link](./docs/api/link.md)
+- [Logo Grid](./docs/api/logoGrid.md)
 - [Main Menu](./docs/api/mainMenu.md)
 - [Secondary Menu](./docs/api/secondaryMenu.md)
 - [Social Menu](./docs/api/socialMenu.md)

--- a/docs/api/logoGrid.md
+++ b/docs/api/logoGrid.md
@@ -14,8 +14,7 @@ import { LogoGrid } from 'forcepoint-shared-components';
 | --- | --- | --- | --- |
 | imageComponent | `elementType` | `img` | Specifies the root node's element type for individual logos. It accepts a string for a standard HTML `img` element or a custom component. Defaults to `img` |
 | items | `LogoInfo[]` | `-` | Required. An array of objects containing information about each logo. See the LogoInfo type for details. |
-| subtitle | `string` | `-` | Optional. A subtitle or description for the LogoGrid, displayed above the logos. |
-| title | `string` | `-` | Optional. A title for the LogoGrid, displayed above the subtitle and logos. |
+| title | `string` | `-` | Optional. A title for the LogoGrid, displayed above the logos. |
 
 ## LogoInfo Type
 
@@ -23,13 +22,15 @@ import { LogoGrid } from 'forcepoint-shared-components';
 | --- | --- | --- | --- |
 | alt | `string` | `-` | Required. Alternative text for the logo image. |
 | src | `string` | `-` | Required. The source URL of the logo image. |
+| height | `string` | `-` | Optional. The height of the image. If provided, it sets the `height` attribute on the image tag. |
+| width | `string` | `-` | Optional. The width of the image. If provided, it sets the `width` attribute on the image tag. |
 
 ## Usage
 
 Below is an example of how to use the `LogoGrid` component:
 
 ```jsx
-import { LogoGrid } from 'tu-paquete-de-componentes';
+import { LogoGrid } from 'forcepoint-shared-components';
 
 const logos = [
   { alt: 'Brand 1', src: '/path-to-brand1-logo.png' },
@@ -39,7 +40,6 @@ const logos = [
 
 <LogoGrid
   items={logos}
-  title="Our Partners"
-  subtitle="Explore the brands we collaborate with."
+  title="Figma ipsum component variant main layer. Scrolling flows."
 />
 ```

--- a/docs/api/logoGrid.md
+++ b/docs/api/logoGrid.md
@@ -1,0 +1,45 @@
+# LogoGrid Component API
+
+The LogoGrid component is designed to display a grid of logos, typically used to showcase a collection of brand logos or images. Below is the documentation for the LogoGrid component.
+
+## Import
+
+```javascript
+import { LogoGrid } from 'forcepoint-shared-components';
+```
+
+## Props
+
+| Name | Type | Default | Description |
+| --- | --- | --- | --- |
+| imageComponent | `elementType` | `img` | Specifies the root node's element type for individual logos. It accepts a string for a standard HTML `img` element or a custom component. Defaults to `img` |
+| items | `LogoInfo[]` | `-` | Required. An array of objects containing information about each logo. See the LogoInfo type for details. |
+| subtitle | `string` | `-` | Optional. A subtitle or description for the LogoGrid, displayed above the logos. |
+| title | `string` | `-` | Optional. A title for the LogoGrid, displayed above the subtitle and logos. |
+
+## LogoInfo Type
+
+| Name | Type | Default | Description |
+| --- | --- | --- | --- |
+| alt | `string` | `-` | Required. Alternative text for the logo image. |
+| src | `string` | `-` | Required. The source URL of the logo image. |
+
+## Usage
+
+Below is an example of how to use the `LogoGrid` component:
+
+```jsx
+import { LogoGrid } from 'tu-paquete-de-componentes';
+
+const logos = [
+  { alt: 'Brand 1', src: '/path-to-brand1-logo.png' },
+  { alt: 'Brand 2', src: '/path-to-brand2-logo.png' },
+  // Add more logos as needed
+];
+
+<LogoGrid
+  items={logos}
+  title="Our Partners"
+  subtitle="Explore the brands we collaborate with."
+/>
+```

--- a/src/lib/components/02-components/logo-grid/logo-grid.stories.tsx
+++ b/src/lib/components/02-components/logo-grid/logo-grid.stories.tsx
@@ -22,8 +22,7 @@ function duplicateArrayItems(arr: LogoInfo[], times: number) {
 
 export const Default: Story = {
   args: {
-    title: 'Test Title',
-    subtitle: 'Test Subtitle',
+    title: 'Figma ipsum component variant main layer. Scrolling flows.',
     items: duplicateArrayItems(logoItems, 32),
   },
 };

--- a/src/lib/components/02-components/logo-grid/logo-grid.stories.tsx
+++ b/src/lib/components/02-components/logo-grid/logo-grid.stories.tsx
@@ -1,0 +1,29 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import LogoGrid, { LogoInfo } from './logo-grid';
+
+const logoItems: LogoInfo[] = [
+  {
+    src: 'https://4kdev-forcepoint.pantheonsite.io/sites/default/files/styles/icon_default_small/public/icons/logo-boldon-james-stacked.png?itok=2dzm_0n6',
+    alt: 'Boldon James',
+  },
+];
+
+const meta = {
+  title: 'Components/Logo Grid',
+  component: LogoGrid,
+} satisfies Meta<typeof LogoGrid>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+function duplicateArrayItems(arr: LogoInfo[], times: number) {
+  return arr.flatMap((item) => Array(times).fill(item));
+}
+
+export const Default: Story = {
+  args: {
+    title: 'Test Title',
+    subtitle: 'Test Subtitle',
+    items: duplicateArrayItems(logoItems, 32),
+  },
+};

--- a/src/lib/components/02-components/logo-grid/logo-grid.tsx
+++ b/src/lib/components/02-components/logo-grid/logo-grid.tsx
@@ -1,0 +1,110 @@
+import { ElementType, useEffect, useState } from 'react';
+import Button from '../../01-elements/button/button';
+import { cn } from '../../../utils/tailwind-merge';
+
+export type LogoInfo = {
+  alt: string;
+  src: string;
+};
+
+export type LogoGridProps = {
+  imageComponent?: ElementType;
+  items: LogoInfo[];
+  showLessText?: string;
+  showMoreText?: string;
+  subtitle?: string;
+  title?: string;
+};
+
+const templateColumns: Record<number, string> = {
+  3: 'grid-cols-2 sm:grid-cols-3',
+  4: 'grid-cols-2 sm:grid-cols-4',
+  5: 'grid-cols-2 sm:grid-cols-4 lg:grid-cols-5',
+  6: 'grid-cols-2 sm:grid-cols-4 lg:grid-cols-6',
+};
+
+export default function LogoGrid({
+  imageComponent: Element = 'img',
+  items,
+  showLessText = 'Show less',
+  showMoreText = 'Show more',
+  subtitle,
+  title,
+}: LogoGridProps) {
+  const [isMobile, setIsMobile] = useState<boolean>();
+  const [isExpanded, setIsExpanded] = useState<boolean>(false);
+  const maxElements = isMobile ? 10 : 30;
+
+  useEffect(() => {
+    const handleResize = () => {
+      const isMobile = window.innerWidth < 950;
+      setIsMobile(isMobile);
+    };
+
+    window.addEventListener('resize', handleResize);
+    setTimeout(handleResize, 100);
+
+    return () => {
+      window.removeEventListener('resize', handleResize);
+    };
+  }, []);
+
+  const handleExpand = () => {
+    setIsExpanded(!isExpanded);
+  };
+
+  const displayItems = isExpanded ? items : items.slice(0, maxElements) || [];
+  const columns: number = items?.length < 6 ? items?.length : 6;
+  const heightExceeded = items?.length > maxElements;
+
+  return (
+    <div className="mx-auto my-md md:max-w-screen-lg">
+      {(title || subtitle) && (
+        <div className="my-md flex flex-col gap-md md:my-lg">
+          {title && (
+            <h2 className="text-center text-h3 font-light text-black md:text-h1">
+              {title}
+            </h2>
+          )}
+          {subtitle && (
+            <h3 className="text-center text-h4 font-light text-grey md:text-h3">
+              {subtitle}
+            </h3>
+          )}
+        </div>
+      )}
+      <div className="relative">
+        <ul
+          className={cn(
+            'mx-auto grid w-fit grid-cols-2',
+            templateColumns[columns],
+          )}
+        >
+          {!!displayItems?.length &&
+            displayItems.map((item: LogoInfo, index: number) => (
+              <li
+                key={index}
+                className="h-[100px] w-[170px] px-lg py-md sm:w-[200px]"
+              >
+                <Element
+                  className="mx-auto h-full w-full object-contain"
+                  src={item.src}
+                  alt={item.alt}
+                />
+              </li>
+            ))}
+        </ul>
+        {heightExceeded && !isExpanded && (
+          <div className="absolute bottom-0 h-[70px] w-full bg-gradient-to-t from-white to-transparent"></div>
+        )}
+      </div>
+      {heightExceeded && (
+        <div className="mx-auto mt-md w-fit">
+          <Button onClick={handleExpand}>
+            {isExpanded ? showLessText : showMoreText}
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/lib/components/02-components/logo-grid/logo-grid.tsx
+++ b/src/lib/components/02-components/logo-grid/logo-grid.tsx
@@ -1,6 +1,5 @@
-import { ElementType, useEffect, useState } from 'react';
-import Button from '../../01-elements/button/button';
 import { cn } from '../../../utils/tailwind-merge';
+import { ElementType } from 'react';
 
 export type LogoInfo = {
   alt: string;
@@ -10,8 +9,6 @@ export type LogoInfo = {
 export type LogoGridProps = {
   imageComponent?: ElementType;
   items: LogoInfo[];
-  showLessText?: string;
-  showMoreText?: string;
   subtitle?: string;
   title?: string;
 };
@@ -26,85 +23,50 @@ const templateColumns: Record<number, string> = {
 export default function LogoGrid({
   imageComponent: Element = 'img',
   items,
-  showLessText = 'Show less',
-  showMoreText = 'Show more',
   subtitle,
   title,
 }: LogoGridProps) {
-  const [isMobile, setIsMobile] = useState<boolean>();
-  const [isExpanded, setIsExpanded] = useState<boolean>(false);
-  const maxElements = isMobile ? 10 : 30;
-
-  useEffect(() => {
-    const handleResize = () => {
-      const isMobile = window.innerWidth < 950;
-      setIsMobile(isMobile);
-    };
-
-    window.addEventListener('resize', handleResize);
-    setTimeout(handleResize, 100);
-
-    return () => {
-      window.removeEventListener('resize', handleResize);
-    };
-  }, []);
-
-  const handleExpand = () => {
-    setIsExpanded(!isExpanded);
-  };
-
-  const displayItems = isExpanded ? items : items.slice(0, maxElements) || [];
   const columns: number = items?.length < 6 ? items?.length : 6;
-  const heightExceeded = items?.length > maxElements;
+
+  const titleRendered = () => (
+    <h2
+      className={cn(
+        'my-md text-center text-h3 font-light leading-none text-black md:my-lg md:text-h1',
+        { 'md:mb-md': subtitle },
+      )}
+    >
+      {title}
+    </h2>
+  );
+
+  const subtitleRendered = () => (
+    <h3 className="mb-md text-center text-h4 font-light leading-none text-grey md:mb-lg md:text-h3">
+      {subtitle}
+    </h3>
+  );
+
+  const renderLogoItem = (item: LogoInfo, index: number) => (
+    <li key={index} className="h-[100px] w-[170px] px-lg py-md sm:w-[200px]">
+      <Element
+        className="mx-auto h-full w-full object-contain"
+        src={item.src}
+        alt={item.alt}
+      />
+    </li>
+  );
 
   return (
     <div className="mx-auto my-md md:max-w-screen-lg">
-      {(title || subtitle) && (
-        <div className="my-md flex flex-col gap-md md:my-lg">
-          {title && (
-            <h2 className="text-center text-h3 font-light text-black md:text-h1">
-              {title}
-            </h2>
-          )}
-          {subtitle && (
-            <h3 className="text-center text-h4 font-light text-grey md:text-h3">
-              {subtitle}
-            </h3>
-          )}
-        </div>
-      )}
-      <div className="relative">
-        <ul
-          className={cn(
-            'mx-auto grid w-fit grid-cols-2',
-            templateColumns[columns],
-          )}
-        >
-          {!!displayItems?.length &&
-            displayItems.map((item: LogoInfo, index: number) => (
-              <li
-                key={index}
-                className="h-[100px] w-[170px] px-lg py-md sm:w-[200px]"
-              >
-                <Element
-                  className="mx-auto h-full w-full object-contain"
-                  src={item.src}
-                  alt={item.alt}
-                />
-              </li>
-            ))}
-        </ul>
-        {heightExceeded && !isExpanded && (
-          <div className="absolute bottom-0 h-[70px] w-full bg-gradient-to-t from-white to-transparent"></div>
+      {title && titleRendered()}
+      {subtitle && subtitleRendered()}
+      <ul
+        className={cn(
+          'mx-auto grid w-fit grid-cols-2',
+          templateColumns[columns],
         )}
-      </div>
-      {heightExceeded && (
-        <div className="mx-auto mt-md w-fit">
-          <Button onClick={handleExpand}>
-            {isExpanded ? showLessText : showMoreText}
-          </Button>
-        </div>
-      )}
+      >
+        {items?.length > 0 && items.map(renderLogoItem)}
+      </ul>
     </div>
   );
 }

--- a/src/lib/components/02-components/logo-grid/logo-grid.tsx
+++ b/src/lib/components/02-components/logo-grid/logo-grid.tsx
@@ -32,6 +32,7 @@ export default function LogoGrid({
   const titleRendered = title ? (
     <Typography
       variant="h2"
+      component="h2"
       className="mb-md text-center font-semibold leading-none text-navy md:mb-lg"
     >
       {title}

--- a/src/lib/components/02-components/logo-grid/logo-grid.tsx
+++ b/src/lib/components/02-components/logo-grid/logo-grid.tsx
@@ -17,10 +17,10 @@ export type LogoGridProps = {
 };
 
 const templateColumns: Record<number, string> = {
-  3: 'grid-cols-2 sm:grid-cols-3',
-  4: 'grid-cols-2 sm:grid-cols-4',
-  5: 'grid-cols-2 sm:grid-cols-4 lg:grid-cols-5',
-  6: 'grid-cols-2 sm:grid-cols-4 lg:grid-cols-6',
+  3: 'sm:grid-cols-3',
+  4: 'sm:grid-cols-4',
+  5: 'sm:grid-cols-4 lg:grid-cols-5',
+  6: 'sm:grid-cols-4 lg:grid-cols-6',
 };
 
 export default function LogoGrid({

--- a/src/lib/components/02-components/logo-grid/logo-grid.tsx
+++ b/src/lib/components/02-components/logo-grid/logo-grid.tsx
@@ -1,15 +1,17 @@
 import { cn } from '../../../utils/tailwind-merge';
 import { ElementType } from 'react';
+import Typography from '../../01-elements/typography/typography';
 
 export type LogoInfo = {
   alt: string;
+  height?: string;
   src: string;
+  width?: string;
 };
 
 export type LogoGridProps = {
   imageComponent?: ElementType;
   items: LogoInfo[];
-  subtitle?: string;
   title?: string;
 };
 
@@ -23,27 +25,18 @@ const templateColumns: Record<number, string> = {
 export default function LogoGrid({
   imageComponent: Element = 'img',
   items,
-  subtitle,
   title,
 }: LogoGridProps) {
-  const columns: number = items?.length < 6 ? items?.length : 6;
+  const columns: number = items.length < 6 ? items.length : 6;
 
-  const titleRendered = () => (
-    <h2
-      className={cn(
-        'my-md text-center text-h3 font-light leading-none text-black md:my-lg md:text-h1',
-        { 'md:mb-md': subtitle },
-      )}
+  const titleRendered = title ? (
+    <Typography
+      variant="h2"
+      className="mb-md text-center font-semibold leading-none text-navy md:mb-lg"
     >
       {title}
-    </h2>
-  );
-
-  const subtitleRendered = () => (
-    <h3 className="mb-md text-center text-h4 font-light leading-none text-grey md:mb-lg md:text-h3">
-      {subtitle}
-    </h3>
-  );
+    </Typography>
+  ) : null;
 
   const renderLogoItem = (item: LogoInfo, index: number) => (
     <li key={index} className="h-[100px] w-[170px] px-lg py-md sm:w-[200px]">
@@ -51,14 +44,15 @@ export default function LogoGrid({
         className="mx-auto h-full w-full object-contain"
         src={item.src}
         alt={item.alt}
+        {...(item.width && { width: item.width })}
+        {...(item.height && { height: item.height })}
       />
     </li>
   );
 
   return (
-    <div className="mx-auto my-md md:max-w-screen-lg">
-      {title && titleRendered()}
-      {subtitle && subtitleRendered()}
+    <div className="mx-auto my-lg md:my-xl md:max-w-screen-lg">
+      {titleRendered}
       <ul
         className={cn(
           'mx-auto grid w-fit grid-cols-2',


### PR DESCRIPTION
# Ticket(s)

- [FP-306: Logo grid - FED](https://fourkitchens.clickup.com/t/36718269/FP-306)

## Purpose

**This PR does the following:**
Adds a secondary menu component.

### Functional Testing

- [x] Run `npm install && npm run dev`
- [x] Go to logo grid page. http://localhost:6006/?path=/story/components-logo-grid--default
- [ ] Validates that the component looks and works as expected

### Notes

- [Design](https://www.figma.com/file/HwazkcYwlIm9Yz6NwIQ1b3/Web-Standards?type=design&node-id=2724-73582&mode=design&t=TBZO6t9WQx52SXEk-0)