### PR TITLE
FP-304: Fixes for list item icon variant

### DIFF
--- a/src/lib/components/02-components/list-item/list-item.tsx
+++ b/src/lib/components/02-components/list-item/list-item.tsx
@@ -18,8 +18,8 @@ export type ListItemProps = {
   icon?: {
     url: string;
     alt?: string | null;
-    height: number;
-    width: number;
+    height: number | 'auto';
+    width: number | 'auto';
   };
 };
 
@@ -68,6 +68,7 @@ export default function ListItem({
         alt={icon.alt ?? ''}
         height={icon.height}
         width={icon.width}
+        className="flex-shrink-0 flex-grow-0"
       />
     ) : null,
   };

--- a/src/lib/components/02-components/list-item/list-item.tsx
+++ b/src/lib/components/02-components/list-item/list-item.tsx
@@ -46,8 +46,10 @@ export default function ListItem({
     ],
     {
       flex: style !== 'none',
+      'items-start': style !== 'none',
       'gap-md': style === 'checkmark',
-      'gap-lg': style === 'icon',
+      'gap-sm': style === 'icon',
+      'sm:gap-lg': style === 'icon',
       'mb-md': style === 'checkmark',
       'mt-md pb-md sm:mt-lg sm:pb-lg': style !== 'checkmark',
       'border-b-2 border-b-brumosa': style !== 'checkmark',

--- a/src/lib/components/02-components/list-item/list-item.tsx
+++ b/src/lib/components/02-components/list-item/list-item.tsx
@@ -62,14 +62,16 @@ export default function ListItem({
       <CircleCheckmarkIcon className="mt-xs flex-shrink-0 flex-grow-0 text-teal" />
     ),
     icon: icon ? (
-      <img
-        src={icon.url}
-        role="presentation"
-        alt={icon.alt ?? ''}
-        height={icon.height}
-        width={icon.width}
-        className="flex-shrink-0 flex-grow-0"
-      />
+      <div className="flex-shrink-0 flex-grow-0 basis-[50px] sm:basis-[80px]">
+        <img
+          src={icon.url}
+          role="presentation"
+          alt={icon.alt ?? ''}
+          height={icon.height}
+          width={icon.width}
+          className="w-full h-auto"
+        />
+      </div>
     ) : null,
   };
 


### PR DESCRIPTION
# Ticket(s)

- [FP-304: List + List Item FED](https://fourkitchens.clickup.com/t/36718269/FP-304)

## Purpose

- Fixes in "icon" variant of the list item component:
  - Fix image vertical alignment
  - Reduce gap in mobile
  - Update types to handle "auto" values for width and height
  - Limit icon width

### Functional Testing

- [x] Visit the [List Item > Icon component page](http://localhost:6006/?path=/story/components-list-item--icon) in Storybook
- [x] Confirm that the icon is aligned to the top in all resolutions
- [x] Confirm that the gap between the icon and the text is smaller in mobile
- [x] Confirm that the icon has a max width of 80px in desktop and 50px  in mobile and that the height gets automatically adjusted to keep the aspect ratio

### Notes

- Changes requested in this PR: https://github.com/fourkitchens/forcepoint-nextjs-page-router/pull/59
