### PR TITLE
feat(260): Social media icons exported

### DIFF
--- a/src/lib/components/index.ts
+++ b/src/lib/components/index.ts
@@ -1,130 +1,135 @@
 export { default as ArrowRightIcon } from './00-tokens/icons/arrow-right-icon';
 export { default as CloseIcon } from './00-tokens/icons/close-icon';
+export { default as FacebookIcon } from './00-tokens/icons/facebook-icon';
+export { default as LinkedInIcon } from './00-tokens/icons/linkedin-icon';
 export { default as MenuIcon } from './00-tokens/icons/menu-icon';
+export { default as TwitterIcon } from './00-tokens/icons/twitter-icon';
 export {
   default as Button,
-  type ButtonProps,
+  type ButtonProps
 } from './01-elements/button/button';
 export { default as Img, type ImgProps } from './01-elements/img/img';
 export { default as Link, type LinkProps } from './01-elements/link/link';
 export {
   default as Typography,
-  type TypographyProps,
+  type TypographyProps
 } from './01-elements/typography/typography';
 export {
+  default as FlyoutBanner,
+  type FlyoutBannerDateRange,
+  type FlyoutBannerLocation,
+  type FlyoutBannerProps
+} from './02-components/banners/flyout/flyout-banner';
+export {
+  default as MastheadBanner,
+  type BannerBackgroundColor,
+  type BannerLinkProps,
+  type MastheadBannerProps
+} from './02-components/banners/masthead/masthead-banner';
+export {
   default as Branding,
-  type BrandingProps,
+  type BrandingProps
 } from './02-components/branding/branding';
 export {
   default as Breadcrumb,
-  type BreadcrumbProps,
+  type BreadcrumbProps
 } from './02-components/breadcrumb/breadcrumb';
 export {
   default as Callout,
   type CalloutColorVariant,
   type CalloutImageDetails,
   type CalloutLinkDetails,
-  type CalloutProps,
+  type CalloutProps
 } from './02-components/callout/callout';
 export {
   default as CTA,
-  type CtaProps,
-  type CtaTheme,
   type CtaLinkDetails,
+  type CtaProps,
+  type CtaTheme
 } from './02-components/cta/cta';
 export {
   default as FeaturedResourceCard,
-  type FeaturedResourceCardProps,
+  type FeaturedResourceCardProps
 } from './02-components/featured-resource/featured-resource--card';
 export {
   default as FeaturedResourceListItem,
-  type FeaturedResourceListItemProps,
+  type FeaturedResourceListItemProps
 } from './02-components/featured-resource/featured-resource--list-item';
 export {
   default as HubspotFormWrapper,
-  type HubspotFormWrapperProps,
+  type HubspotFormWrapperProps
 } from './02-components/form/hubspot-form-wrapper';
 export {
   default as ListItem,
   type ListItemProps,
-  type ListItemStyleType,
+  type ListItemStyleType
 } from './02-components/list-item/list-item';
 export { default as List, type ListProps } from './02-components/list/list';
 export {
   default as LogoGrid,
   type LogoGridProps,
-  type LogoInfo,
+  type LogoInfo
 } from './02-components/logo-grid/logo-grid';
 export {
   default as MarketoReference,
   type MarketoReferenceColor,
   type MarketoReferenceFormStyle,
-  type MarketoReferenceImageDetails,
+  type MarketoReferenceImageDetails
 } from './02-components/marketo-reference/marketo-reference';
 export {
   default as FooterMenu,
-  type FooterMenuProps,
+  type FooterMenuProps
 } from './02-components/menus/footer/footer-menu';
 export {
   default as LanguageSwitcher,
   type LanguageSwitcherProps,
-  type LocaleMenuItem,
+  type LocaleMenuItem
 } from './02-components/menus/language-switcher/language-switcher';
 export {
   default as LegalMenu,
   type LegalMenuItem,
-  type LegalMenuProps,
+  type LegalMenuProps
 } from './02-components/menus/legal-menu/legal-menu';
 export {
   default as MainMenu,
   type MainMenuItemProps,
-  type MainMenuProps,
+  type MainMenuProps
 } from './02-components/menus/main-menu/main-menu';
 export {
   default as SecondaryMenu,
   type SecondaryMenuItemProps,
-  type SecondaryMenuProps,
+  type SecondaryMenuProps
 } from './02-components/menus/secondary-menu/secondary-menu';
 export {
   default as SocialMenu,
   type SocialMenuItem,
-  type SocialMenuProps,
+  type SocialMenuProps
 } from './02-components/menus/social-menu/social-menu';
 export {
   default as SearchInput,
-  type SearchProps,
+  type SearchProps
 } from './02-components/search-input/search-input';
 export {
   default as ContentSlideItem,
-  type ContentSlideItemProps,
+  type ContentSlideItemProps
 } from './02-components/slider/content-slide-item';
 export {
   default as ContentSlider,
-  type ContentSliderProps,
+  type ContentSliderProps
 } from './02-components/slider/content-slider';
 export {
-  default as MastheadBanner,
-  type MastheadBannerProps,
-  type BannerBackgroundColor,
-  type BannerLinkProps,
-} from './02-components/banners/masthead/masthead-banner';
-export {
-  default as FlyoutBanner,
-  type FlyoutBannerProps,
-  type FlyoutBannerDateRange,
-  type FlyoutBannerLocation,
-} from './02-components/banners/flyout/flyout-banner';
-export { default as StickyHeader,
+  default as StickyHeader,
   type HeaderCta,
-  type StickyHeaderProps,
+  type StickyHeaderProps
 } from './02-components/sticky-header/sticky-header';
 export { type TableProps } from './02-components/table/table';
 export {
   default as TableColumn,
-  type TableColumnProps,
+  type TableColumnProps
 } from './02-components/table/table-column';
 export {
   default as TableRow,
-  type TableRowProps,
+  type TableRowProps
 } from './02-components/table/table-row';
 export { default as Table } from './02-components/table/table-wrapper';
+


### PR DESCRIPTION
# Ticket(s)

- [FP-260: Profile FED](https://fourkitchens.clickup.com/t/36718269/FP-260)

## Purpose
Export the Linked In, Twitter and Facebook icons to be used in the next library
### Functional Testing
- [x] On your local run `npm run yalc-publish` 
- [x] Then continue steps on https://github.com/fourkitchens/forcepoint-nextjs-page-router/pull/73
- [x] On the next app the LinkedIn and Twitter icons should be rendered correctly

## Notes

It seems the file was modified a lot, but actually it was just the prettier formatting the file