### PR TITLE
feat(908): Add link attributes to pager links

### DIFF
--- a/src/lib/components/02-components/pager/pager.tsx
+++ b/src/lib/components/02-components/pager/pager.tsx
@@ -9,6 +9,7 @@ export interface PagerProps extends ComponentPropsWithoutRef<'nav'> {
   previousLabel?: string;
   nextLabel?: string;
   currentPageLabel?: string;
+  linkAttributes?: Record<string, any>;
 }
 
 export default function Pager({
@@ -20,6 +21,7 @@ export default function Pager({
   currentPageLabel = 'of',
   component: Element = 'a',
   totalPages,
+  linkAttributes,
   ...props
 }: PagerProps) {
   function createPageURL(page: number) {
@@ -41,7 +43,8 @@ export default function Pager({
         component={Element}
         as="link"
         color="blue"
-        href={createPageURL(currentPage - 1)}>
+        href={createPageURL(currentPage - 1)}
+        {...linkAttributes}>
         {previousLabel}
       </Button>
     </li>
@@ -58,7 +61,8 @@ export default function Pager({
         component={Element}
         as="link"
         color="blue"
-        href={createPageURL(currentPage + 1)}>
+        href={createPageURL(currentPage + 1)}
+        {...linkAttributes}>
         {nextLabel}
       </Button>
     </li>


### PR DESCRIPTION
# Ticket(s)

- [FP-908: Profile blog listing](https://fourkitchens.clickup.com/t/36718269/FP-908)

## Purpose
Allows to add extra attributes to the page link elements
We needed to [not scroll ](https://nextjs.org/docs/pages/api-reference/components/link#scroll) to the top of the page when we change the page. 

### Functional Testing

- [x] Run `npm run yalc-publish`
- [ ] Continue steps on:  steps on https://github.com/fourkitchens/forcepoint-nextjs-page-router/pull/81