### PR TITLE
FP-939: Hero Banner - Social Share

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ export default {
 - [Main Menu](./docs/api/mainMenu.md)
 - [Secondary Menu](./docs/api/secondaryMenu.md)
 - [Social Menu](./docs/api/socialMenu.md)
+- [Social Share](./docs/api/socialShare.md)
 - [Typography](./docs/api/typography.md)
 
 ## Development

--- a/docs/api/socialShare.md
+++ b/docs/api/socialShare.md
@@ -21,7 +21,9 @@ The component accepts the following props for configuration:
 | `ariaNavLabel` | `string`  | Sets `ariaNavLabel`. |
 | `hasBackground` | `boolean`  | Default `true`. If `true` will, the icon will have a rounded grey rectangle as a background for each icon. |
 | `iconColor` | `string`  | Default `text-gray`. Sets the color of the icons |
-| `useSmallIcons` | `boolean`  | Default `false`. If true, icons will be set to 16px. |
+| `useSmallIcons` | `boolean`  | Default `false`. If `true`, icons will be set to 16px. |
+| `horizontal` | `boolean`  | Default `false`. If `false`, icons stacks vertically on mobile. |
+
 
 ## Examples
 
@@ -47,5 +49,6 @@ import { SocialShare } from 'forcepoint-shared-components';
   iconColor='text-blue'
   hasBackground={false}
   useSmallIcons={true}
+  horizontal={true}
  />
 ```

--- a/docs/api/socialShare.md
+++ b/docs/api/socialShare.md
@@ -1,0 +1,51 @@
+# SocialShare Component API
+
+The `SocialShare` component is designed for displaying a list of social media icons. It supports linkedin, twitter, and facebook.
+
+## Import
+
+```jsx
+import { SocialShare } from 'forcepoint-shared-components';
+```
+
+## Props
+
+The component accepts the following props for configuration:
+
+| Name    | Type                | Description                                                     |
+|---------|---------------------|-----------------------------------------------------------------|
+| `url` | `string` | Sets the url of what's going to be shared. |
+| `title` | `string`  | Sets the title of what's going to be shared. |
+| `shareText` | `string`  | Sets aria label for each icon. |
+| `className` | `string`  | Adds classes to the wrapper. |
+| `ariaNavLabel` | `string`  | Sets `ariaNavLabel`. |
+| `hasBackground` | `boolean`  | Default `true`. If `true` will, the icon will have a rounded grey rectangle as a background for each icon. |
+| `iconColor` | `string`  | Default `text-gray`. Sets the color of the icons |
+| `useSmallIcons` | `boolean`  | Default `false`. If true, icons will be set to 16px. |
+
+## Examples
+
+```jsx
+import { SocialShare } from 'forcepoint-shared-components';
+
+<SocialShare
+  url='https://www.example.com'
+  title='Example Title'
+  shareText='Share on'
+  ariaNavLabel='Social media sharing'
+ />
+```
+
+```jsx
+import { SocialShare } from 'forcepoint-shared-components';
+
+<SocialShare
+  url='https://www.example.com'
+  title='Example Title'
+  shareText='Share on'
+  ariaNavLabel='Social media sharing'
+  iconColor='text-blue'
+  hasBackground={false}
+  useSmallIcons={true}
+ />
+```

--- a/docs/api/socialShare.md
+++ b/docs/api/socialShare.md
@@ -20,7 +20,7 @@ The component accepts the following props for configuration:
 | `className` | `string`  | Adds classes to the wrapper. |
 | `ariaNavLabel` | `string`  | Sets `ariaNavLabel`. |
 | `hasBackground` | `boolean`  | Default `true`. If `true` will, the icon will have a rounded grey rectangle as a background for each icon. |
-| `iconColor` | `string`  | Default `text-gray`. Sets the color of the icons |
+| `iconColor` | `string`  | Default `text-gray`. Sets the color of the icons using tailwind classes. |
 | `useSmallIcons` | `boolean`  | Default `false`. If `true`, icons will be set to 16px. |
 | `horizontal` | `boolean`  | Default `false`. If `false`, icons stacks vertically on mobile. |
 

--- a/src/lib/components/02-components/social-share/social-share.stories.tsx
+++ b/src/lib/components/02-components/social-share/social-share.stories.tsx
@@ -18,7 +18,7 @@ export const Default: Story = {
   },
 };
 
-export const CustomColor: Story = {
+export const CustomColorNoBackground: Story = {
   args: {
     url: 'https://www.example.com',
     title: 'Example Title',
@@ -29,7 +29,7 @@ export const CustomColor: Story = {
   },
 };
 
-export const SmallIcon: Story = {
+export const SmallIconHorizontal: Story = {
   args: {
     url: 'https://www.example.com',
     title: 'Example Title',
@@ -38,5 +38,6 @@ export const SmallIcon: Story = {
     iconColor: 'text-viola',
     hasBackground: false,
     useSmallIcons: true,
+    horizontal: true,
   },
 };

--- a/src/lib/components/02-components/social-share/social-share.stories.tsx
+++ b/src/lib/components/02-components/social-share/social-share.stories.tsx
@@ -17,3 +17,26 @@ export const Default: Story = {
     ariaNavLabel: 'Social media sharing',
   },
 };
+
+export const CustomColor: Story = {
+  args: {
+    url: 'https://www.example.com',
+    title: 'Example Title',
+    shareText: 'Share on',
+    ariaNavLabel: 'Social media sharing',
+    iconColor: 'text-blue',
+    hasBackground: false,
+  },
+};
+
+export const SmallIcon: Story = {
+  args: {
+    url: 'https://www.example.com',
+    title: 'Example Title',
+    shareText: 'Share on',
+    ariaNavLabel: 'Social media sharing',
+    iconColor: 'text-viola',
+    hasBackground: false,
+    useSmallIcons: true,
+  },
+};

--- a/src/lib/components/02-components/social-share/social-share.stories.tsx
+++ b/src/lib/components/02-components/social-share/social-share.stories.tsx
@@ -24,8 +24,9 @@ export const CustomColorNoBackground: Story = {
     title: 'Example Title',
     shareText: 'Share on',
     ariaNavLabel: 'Social media sharing',
-    iconColor: 'text-blue',
+    iconColor: 'text-blue hover:text-viola',
     hasBackground: false,
+    horizontal: true,
   },
 };
 

--- a/src/lib/components/02-components/social-share/social-share.tsx
+++ b/src/lib/components/02-components/social-share/social-share.tsx
@@ -54,9 +54,8 @@ export default function SocialShare({
     <nav aria-label={ariaNavLabel} className={className}>
       <ul
         className={cn(
-          'flex md:flex-col',
-          hasBackground && 'gap-sm',
-          horizontal && 'flex-row md:flex-row',
+          'flex gap-sm md:flex-col',
+          horizontal && 'flex-row gap-5 md:flex-row',
         )}>
         {socialButtons.map(({ platform, shareUrl, icon, ariaLabel }) => (
           <li key={platform}>
@@ -65,8 +64,9 @@ export default function SocialShare({
               aria-label={ariaLabel}
               onClick={() => genericSocialShare(shareUrl, ariaLabel)}
               className={cn(
-                'flex h-[40px] w-[40px] items-center justify-center rounded-[10px]  hover:bg-mercury',
-                hasBackground && 'bg-azure',
+                'flex items-center justify-center',
+                hasBackground &&
+                  'h-[40px] w-[40px] rounded-[10px] bg-azure hover:bg-mercury',
               )}>
               {icon}
             </button>

--- a/src/lib/components/02-components/social-share/social-share.tsx
+++ b/src/lib/components/02-components/social-share/social-share.tsx
@@ -10,6 +10,7 @@ export type SocialShareProps = {
   hasBackground?: boolean;
   iconColor?: string;
   useSmallIcons?: boolean;
+  horizontal?: boolean;
 };
 
 function genericSocialShare(url: string, socialNetwork: string) {
@@ -25,6 +26,7 @@ export default function SocialShare({
   iconColor = 'text-grey',
   hasBackground = true,
   useSmallIcons = false,
+  horizontal = false,
 }: SocialShareProps) {
   const iconClass = `${iconColor} ${useSmallIcons ? 'w-[16px] h-[16px]' : 'w-[20px] h-[20px]'}`;
   const socialButtons = [
@@ -50,7 +52,12 @@ export default function SocialShare({
 
   return (
     <nav aria-label={ariaNavLabel} className={className}>
-      <ul className={cn('flex md:flex-col', hasBackground && 'gap-sm')}>
+      <ul
+        className={cn(
+          'flex md:flex-col',
+          hasBackground && 'gap-sm',
+          horizontal && 'flex-row md:flex-row',
+        )}>
         {socialButtons.map(({ platform, shareUrl, icon, ariaLabel }) => (
           <li key={platform}>
             <button

--- a/src/lib/components/02-components/social-share/social-share.tsx
+++ b/src/lib/components/02-components/social-share/social-share.tsx
@@ -7,6 +7,9 @@ export type SocialShareProps = {
   shareText?: string;
   className?: string;
   ariaNavLabel?: string;
+  hasBackground?: boolean;
+  iconColor?: string;
+  useSmallIcons?: boolean;
 };
 
 function genericSocialShare(url: string, socialNetwork: string) {
@@ -19,31 +22,35 @@ export default function SocialShare({
   className,
   shareText = 'Share on',
   ariaNavLabel = 'Social media sharing',
+  iconColor = 'text-grey',
+  hasBackground = true,
+  useSmallIcons = false,
 }: SocialShareProps) {
+  const iconClass = `${iconColor} ${useSmallIcons ? 'w-[16px] h-[16px]' : 'w-[20px] h-[20px]'}`;
   const socialButtons = [
     {
       platform: 'LinkedIn',
       shareUrl: `https://www.linkedin.com/shareArticle?mini=true&url=${encodeURIComponent(url)}&title=${encodeURIComponent(title)}`,
-      icon: <LinkedinIcon className="h-[20px] w-[20px] text-grey" />,
+      icon: <LinkedinIcon className={cn(iconClass)} />,
       ariaLabel: `${shareText} LinkedIn`,
     },
     {
       platform: 'Twitter',
       shareUrl: `http://twitter.com/share?text=${title}&url=${encodeURIComponent(url)}`,
-      icon: <TwitterIcon className="h-[20px] w-[20px] text-grey" />,
+      icon: <TwitterIcon className={cn(iconClass)} />,
       ariaLabel: `${shareText} Twitter`,
     },
     {
       platform: 'Facebook',
       shareUrl: `http://www.facebook.com/sharer.php?u=${encodeURIComponent(url)}`,
-      icon: <FacebookIcon className="h-[20px] w-[20px] text-grey" />,
+      icon: <FacebookIcon className={cn(iconClass)} />,
       ariaLabel: `${shareText} Facebook`,
     },
   ];
 
   return (
     <nav aria-label={ariaNavLabel} className={className}>
-      <ul className={cn('flex gap-sm md:flex-col')}>
+      <ul className={cn('flex md:flex-col', hasBackground && 'gap-sm')}>
         {socialButtons.map(({ platform, shareUrl, icon, ariaLabel }) => (
           <li key={platform}>
             <button
@@ -51,7 +58,8 @@ export default function SocialShare({
               aria-label={ariaLabel}
               onClick={() => genericSocialShare(shareUrl, ariaLabel)}
               className={cn(
-                'flex h-[40px] w-[40px] items-center justify-center rounded-[10px] bg-azure hover:bg-mercury',
+                'flex h-[40px] w-[40px] items-center justify-center rounded-[10px]  hover:bg-mercury',
+                hasBackground && 'bg-azure',
               )}>
               {icon}
             </button>


### PR DESCRIPTION
# Ticket(s)

- [FP-939: Hero Banner - Social Share](https://fourkitchens.clickup.com/t/36718269/FP-939)

## Purpose

**This PR does the following:**

- Adds prop for icon color
- Adds prop to render or not a bg color around icons
- Adds prop to render smaller icons
- Creates documentation
- Creates new stories for icon color and smaller icons

### Functional Testing

- [ ] Go to the social share story
- [ ] Visit the custom color story
- [ ] Visit the smaller icons story

### Readme Updates

- Doc file for the social share is linked on Readme
