### PR TITLE
FP-1082: landing page final plea cta width and image bleed

### DIFF
--- a/src/lib/components/02-components/marketo-reference/marketo-reference.tsx
+++ b/src/lib/components/02-components/marketo-reference/marketo-reference.tsx
@@ -112,10 +112,10 @@ export default function MarketoReference({
           className={cn(
             'w-full px-md py-lg lg:px-lg lg:py-xl',
             marketoReferenceFormStyles[formStyle],
-            {
-              'lg:max-w-[540px]':
-                formStyle !== 'aside_contained_image_overflow_top',
-            },
+
+            formStyle !== 'aside_contained_image_overflow_top'
+              ? 'lg:max-w-[1/2]'
+              : 'lg:max-w-[540px]',
           )}>
           {renderedMarketoForm}
         </div>

--- a/src/lib/components/02-components/marketo-reference/marketo-reference.tsx
+++ b/src/lib/components/02-components/marketo-reference/marketo-reference.tsx
@@ -106,19 +106,14 @@ export default function MarketoReference({
           contentClassName,
         )}>
         {renderedImage && (
-          <div
-            className={cn('hidden md:block md:w-full', {
-              'md:-mt-5': formStyle === 'aside_contained_image_overflow_top',
-            })}>
-            {renderedImage}
-          </div>
+          <div className={cn('hidden md:block md:w-full')}>{renderedImage}</div>
         )}
         <div
           className={cn(
             'w-full px-md py-lg lg:px-lg lg:py-xl',
             marketoReferenceFormStyles[formStyle],
             {
-              'lg:max-w-1/2':
+              'lg:max-w-[540px]':
                 formStyle !== 'aside_contained_image_overflow_top',
             },
           )}>


### PR DESCRIPTION

# Ticket(s)

- [FP-1082: landing page final plea cta width and image bleed](https://fourkitchens.clickup.com/t/36718269/FP-1082)

## Purpose

**This PR does the following:**

- Fixes bugs in marketo reference:
  - give a max width to the form
  - remove negative margin that cuts the image
