### PR TITLE
FP-1080: Logogrid not showing sub title field

### DIFF
--- a/docs/api/logoGrid.md
+++ b/docs/api/logoGrid.md
@@ -15,6 +15,7 @@ import { LogoGrid } from 'forcepoint-shared-components';
 | imageComponent | `elementType` | `img` | Specifies the root node's element type for individual logos. It accepts a string for a standard HTML `img` element or a custom component. Defaults to `img` |
 | items | `LogoInfo[]` | `-` | Required. An array of objects containing information about each logo. See the LogoInfo type for details. |
 | title | `string` | `-` | Optional. A title for the LogoGrid, displayed above the logos. |
+| subtitle | `string` | `-` | Optional. A subtitle for the LogoGrid, displayed below the title. |
 
 ## LogoInfo Type
 
@@ -41,5 +42,6 @@ const logos = [
 <LogoGrid
   items={logos}
   title="Figma ipsum component variant main layer. Scrolling flows."
+  subtitle="Figma ipsum component variant main layer. Scrolling flows."
 />
 ```

--- a/src/lib/components/02-components/logo-grid/logo-grid.stories.tsx
+++ b/src/lib/components/02-components/logo-grid/logo-grid.stories.tsx
@@ -3,7 +3,7 @@ import LogoGrid, { LogoInfo } from './logo-grid';
 
 const logoItems: LogoInfo[] = [
   {
-    src: 'https://4kdev-forcepoint.pantheonsite.io/sites/default/files/styles/icon_default_small/public/icons/logo-boldon-james-stacked.png?itok=2dzm_0n6',
+    src: 'https://www.forcepoint.com/sites/default/files/styles/icon_default_small/public/icons/logo_6.png',
     alt: 'Boldon James',
   },
 ];

--- a/src/lib/components/02-components/logo-grid/logo-grid.stories.tsx
+++ b/src/lib/components/02-components/logo-grid/logo-grid.stories.tsx
@@ -23,6 +23,7 @@ function duplicateArrayItems(arr: LogoInfo[], times: number) {
 export const Default: Story = {
   args: {
     title: 'Figma ipsum component variant main layer. Scrolling flows.',
+    subtitle: 'Figma ipsum component variant main layer. Scrolling flows.',
     items: duplicateArrayItems(logoItems, 32),
   },
 };

--- a/src/lib/components/02-components/logo-grid/logo-grid.tsx
+++ b/src/lib/components/02-components/logo-grid/logo-grid.tsx
@@ -13,6 +13,7 @@ export type LogoGridProps = {
   imageComponent?: ElementType;
   items: LogoInfo[];
   title?: string;
+  subtitle?: string;
 };
 
 const templateColumns: Record<number, string> = {
@@ -26,6 +27,7 @@ export default function LogoGrid({
   imageComponent: Element = 'img',
   items,
   title,
+  subtitle
 }: LogoGridProps) {
   const columns: number = items.length < 6 ? items.length : 6;
 
@@ -33,9 +35,19 @@ export default function LogoGrid({
     <Typography
       variant="h2"
       component="h2"
-      className="mb-md text-center font-semibold leading-none text-navy md:mb-lg"
+      className="mb-sm text-center font-semibold leading-none text-navy md:mb-md"
     >
       {title}
+    </Typography>
+  ) : null;
+
+  const subtitleRendered = subtitle ? (
+    <Typography
+      variant="h3"
+      component="h3"
+      className="mb-md text-center font-extralight leading-none text-chateau md:mb-lg"
+    >
+      {subtitle}
     </Typography>
   ) : null;
 
@@ -54,6 +66,7 @@ export default function LogoGrid({
   return (
     <div className="mx-auto my-lg md:my-xl md:max-w-screen-lg">
       {titleRendered}
+      {subtitleRendered}
       <ul
         className={cn(
           'mx-auto grid w-fit grid-cols-2',


### PR DESCRIPTION
# Ticket(s)

- [FP-1080: Logogrid not showing sub title field](https://app.clickup.com/t/36718269/FP-1080)

## Purpose

**This PR does the following:**

- Adds/displays subtitle prop to the LogoGrid component.

### Functional Testing

- [x] Verify the subtitle is now visible.

![Screenshot 2024-07-26 at 6 41 45 PM](https://github.com/user-attachments/assets/e9e91d39-e5dd-48df-abc0-0623451f45f6)

