### PR TITLE
Create new version for the cta banner

### DIFF
--- a/docs/api/ctaBanner.md
+++ b/docs/api/ctaBanner.md
@@ -22,6 +22,8 @@ import { CtaBanner } from 'forcepoint-shared-components';
 | renderedImageComponent | `ReactNode` | - | Renders the image using and external component. |
 | backgroundImage | `CtaImageDetails` | `-` | Details of the background image to be displayed within the call to action. See the `CtaImageDetails` type for details. |
 | imageComponent | `ElementType` | `img` | Specifies the root node's element type for the image. It accepts a string for a standard HTML element or a custom component. Defaults to `img`. |
+| contentRight | `boolean` | `false` | Content will be aligned to the right. |
+
 
 
 ### CtaButtonDetails

--- a/src/lib/components/02-components/cta-banner/cta-banner.stories.tsx
+++ b/src/lib/components/02-components/cta-banner/cta-banner.stories.tsx
@@ -19,5 +19,20 @@ export const Default: Story = {
       url: '#',
     },
     theme: 'azure',
+    contentRight: false,
+  },
+};
+
+export const ContentToTheRight: Story = {
+  args: {
+    title:
+      'Find it hard to keep pace with modern network demands? Read the Four Steps to Future-Ready Network Security.',
+    eyebrow: 'Independent Report',
+    primaryButton: {
+      title: 'Read Now',
+      url: '#',
+    },
+    theme: 'azure',
+    contentRight: true,
   },
 };

--- a/src/lib/components/02-components/cta-banner/cta-banner.tsx
+++ b/src/lib/components/02-components/cta-banner/cta-banner.tsx
@@ -19,6 +19,7 @@ export interface CtaBannerProps extends ComponentPropsWithoutRef<'div'> {
   backgroundImage?: CtaBannerImageDetails;
   imageComponent?: ElementType;
   theme: CtaBannerTheme;
+  contentRight: boolean;
 }
 
 export type CtaButtonDetails = {
@@ -81,6 +82,7 @@ export default function CtaBanner({
   imageComponent: ImageElement = 'img',
   theme,
   className,
+  contentRight = false,
 }: CtaBannerProps) {
   const renderedTitle = renderedTitleComponent ? (
     renderedTitleComponent
@@ -97,7 +99,12 @@ export default function CtaBanner({
       href={primaryButton.url}
       component={ButtonElement}
       color={colorSchema[theme].button}
-      className="mt-md w-full justify-center px-14 py-4 text-h4 md:ml-10 md:mt-0 md:min-w-[230px] lg:w-60">
+      className={cn(
+        'mt-md w-full justify-center transition md:mt-0',
+        contentRight
+          ? 'px-10 py-sm text-body-3'
+          : 'py-4 text-h4 md:min-w-[230px] lg:w-60',
+      )}>
       {primaryButton.title}
     </Button>
   );
@@ -137,8 +144,15 @@ export default function CtaBanner({
             {renderedImage}
           </div>
         )}
-        <div className="flex flex-col md:flex-row md:items-center">
-          <div className="max-w-screen-sm">
+        <div
+          className={cn(
+            'flex flex-col md:items-center',
+            !contentRight ? 'md:flex-row' : 'py-20',
+          )}>
+          <div
+            className={cn(
+              contentRight ? 'mb-5 md:pl-[50%]' : 'max-w-screen-sm',
+            )}>
             {eyebrow && (
               <span
                 className={cn(
@@ -150,7 +164,12 @@ export default function CtaBanner({
             )}
             {renderedTitle}
           </div>
-          {renderedPrimaryButton}
+          <div
+            className={cn(
+              contentRight ? 'self-start md:pl-[50%]' : 'md:ml-10',
+            )}>
+            {renderedPrimaryButton}
+          </div>
         </div>
       </div>
     </div>

--- a/src/lib/components/02-components/form/hubspot-form-wrapper.tsx
+++ b/src/lib/components/02-components/form/hubspot-form-wrapper.tsx
@@ -6,7 +6,7 @@ export type HubspotFormWrapperProps = ComponentPropsWithoutRef<'div'> & {
   headLine?: string | null;
   subHeadLine?: string | null;
   logo?: ReactNode;
-  bgColor?: 'white' | 'navy' | 'blue' | 'azure' | 'black';
+  bgColor?: 'white' | 'navy' | 'blue' | 'azure' | 'black' | 'transparent';
   formType?: 'default' | 'sign-up' | 'demo-request';
 };
 
@@ -53,10 +53,10 @@ export default function HubspotFormWrapper({
           'bg-blue': bgColor === 'blue',
           'bg-azure': bgColor === 'azure',
           'bg-black': bgColor === 'black',
+          'bg-transparent': bgColor === 'transparent',
         },
         className,
-      )}
-    >
+      )}>
       {logo}
       {renderedHeadline}
       {renderedSubheadline}


### PR DESCRIPTION
# Ticket(s)

- [Update cta banner](https://app.asana.com/0/1203386530974194/1207924503344486/f)

## Purpose

**This PR does the following:**

- Adds a content right prop to the CTA banner
- If true, the content will go to the right, the button will be smaller, there will be more vertical padding
- Add the transparent prop to hubspot form wrapper

### Functional Testing

- [ ] Visit the new story about the content to the right on CTA banner
![Screenshot 2024-07-31 at 16 05 52](https://github.com/user-attachments/assets/22b7344d-3fef-40af-ade2-012c33ed72a6)

