### PR TITLE
FP-1109: Check announcement banner flyouts

### DIFF
--- a/src/lib/components/02-components/banners/flyout/flyout-banner.tsx
+++ b/src/lib/components/02-components/banners/flyout/flyout-banner.tsx
@@ -119,7 +119,7 @@ export default function FlyoutBanner({
   const renderedToggleButton = (
     <button
       className={cn(
-        'fixed top-3xl z-40 min-h-[200px] cursor-pointer rounded-l-m bg-sol px-3 py-10 text-center text-h6 [writing-mode:vertical-lr]',
+        'fixed top-56 z-40 min-h-[200px] cursor-pointer rounded-l-m bg-sol px-3 py-10 text-center text-h6 [writing-mode:vertical-lr]',
         toggleTransition,
         {
           'right-0': !showBanner,
@@ -141,7 +141,7 @@ export default function FlyoutBanner({
     >
       <div
         className={cn(
-          'fixed top-3xl z-30 max-w-[350px] rounded-m bg-black',
+          'fixed top-64 z-30 max-w-[380px] rounded-m bg-black',
           toggleTransition,
           {
             'right-sm': showBanner,


### PR DESCRIPTION
# Ticket(s)

- [FP-1109: Check announcement banner flyouts](https://app.clickup.com/t/36718269/FP-1109)
- [FP-1109: Check images on the announcement banner](https://app.clickup.com/t/36718269/FP-1108)

## Purpose

**This PR does the following:**

- Adjusts flyout banner position and Width (Image).

### Functional Testing

- [ ] Verify the new position of the flyout banner and width (380px).

![Screenshot 2024-08-06 at 8 57 31 AM](https://github.com/user-attachments/assets/f7cb3fa2-6439-4a7a-ae3d-6a04e38a6fb5)
