### PR TITLE
New props for lists and CTA

### DIFF
--- a/docs/api/cta.md
+++ b/docs/api/cta.md
@@ -16,6 +16,7 @@ import { CTA } from 'forcepoint-shared-components';
 | link | `string` | `-` | Details of the link associated with the call to action. See the `CtaLinkDetails` type for details. |
 | linkComponent | `string` | `-` | Specifies the root node's element type for the link. It accepts a string for a standard HTML element or a custom component. Defaults to a (anchor). |
 | theme | `azure` \| `black` \| `navy` \| `warp` \| `gray` \| `warp` | `glow` | `-` | Additional theme for the CTA component. |
+| showTextOnly | `boolean` | `-` | When true, it will use a link text instead of a button |
 
 
 ### CtaLinkDetails

--- a/src/lib/components/02-components/cta/cta.stories.tsx
+++ b/src/lib/components/02-components/cta/cta.stories.tsx
@@ -19,3 +19,15 @@ export const Default: Story = {
     },
   },
 };
+
+export const CtaTextOnly: Story = {
+  args: {
+    theme: 'azure',
+    header: 'Schedule a Live Demo of Forcepoint ONE',
+    link: {
+      title: 'Secondary',
+      url: '/',
+    },
+    showTextOnly: true,
+  },
+};

--- a/src/lib/components/02-components/cta/cta.tsx
+++ b/src/lib/components/02-components/cta/cta.tsx
@@ -8,6 +8,7 @@ import Typography from '../../01-elements/typography/typography';
 import GlowBgImage from '../../../assets/img/components/cta-glow.png';
 import GrayBgImage from '../../../assets/img/components/cta-gray.png';
 import WarpBgImage from '../../../assets/img/components/cta-warp.png';
+import Link from '../../01-elements/link/link';
 
 export type CtaLinkDetails = {
   title: string;
@@ -20,6 +21,7 @@ export interface CtaProps extends ComponentPropsWithoutRef<'div'> {
   linkComponent?: ElementType;
   theme?: CtaTheme;
   contentClassName?: string;
+  showTextOnly?: boolean;
 }
 
 export type CtaTheme = 'azure' | 'black' | 'glow' | 'gray' | 'navy' | 'warp';
@@ -76,6 +78,7 @@ export default function CTA({
   linkComponent: LinkElement = 'a',
   theme = 'azure',
   contentClassName,
+  showTextOnly,
   ...props
 }: CtaProps) {
   const cardStyles: CSSProperties = {};
@@ -87,7 +90,7 @@ export default function CTA({
   if (bgImages[theme]) {
     cardStyles.backgroundImage = `url(${bgImages[theme]})`;
   }
-
+  const Component = showTextOnly ? Link : Button;
   return (
     <div
       {...props}
@@ -97,7 +100,11 @@ export default function CTA({
         className,
       )}
       style={cardStyles}>
-      <div className={cn('flex flex-col items-center gap-y-lg text-center', contentClassName)}>
+      <div
+        className={cn(
+          'flex flex-col items-center gap-y-lg text-center',
+          contentClassName,
+        )}>
         {header && (
           <Typography
             variant="h1"
@@ -107,16 +114,16 @@ export default function CTA({
           </Typography>
         )}
         {link && (
-          <Button
+          <Component
             animated
             as="link"
             href={link.url}
             component={LinkElement}
-            endIcon={<ArrowRightIcon />}
+            endIcon={!showTextOnly && <ArrowRightIcon />}
             color={colorSchema[theme].button}
             className="mt-md w-full justify-center md:w-fit">
             {link.title}
-          </Button>
+          </Component>
         )}
       </div>
     </div>

--- a/src/lib/components/02-components/list-item/list-item.stories.tsx
+++ b/src/lib/components/02-components/list-item/list-item.stories.tsx
@@ -61,5 +61,26 @@ export const Icon: Story = {
       height: 80,
       width: 64,
     },
+    noBottomBorder: false,
+  },
+};
+
+export const IconWithoutBottomBorder: Story = {
+  ...Default,
+  args: {
+    title: 'Figma ipsum component variant main layer. Scrolling flows.',
+    style: 'icon',
+    text: (
+      <p>
+        Fugiat laborum id culpa magna laboris dolor elit enim nostrud anim
+        deserunt. Culpa proident veniam esse minim.
+      </p>
+    ),
+    icon: {
+      url: 'https://placehold.co/64x80',
+      height: 80,
+      width: 64,
+    },
+    noBottomBorder: true,
   },
 };

--- a/src/lib/components/02-components/list-item/list-item.tsx
+++ b/src/lib/components/02-components/list-item/list-item.tsx
@@ -21,6 +21,7 @@ export type ListItemProps = {
     height: number | 'auto';
     width: number | 'auto';
   };
+  noBottomBorder?: boolean;
 };
 
 export default function ListItem({
@@ -31,6 +32,7 @@ export default function ListItem({
   icon,
   link,
   linkComponent = 'a',
+  noBottomBorder,
 }: ListItemProps) {
   const containerClasses = cn(
     [
@@ -53,6 +55,7 @@ export default function ListItem({
       'mb-md': style === 'checkmark',
       'mt-md pb-md sm:mt-lg sm:pb-lg': style !== 'checkmark',
       'border-b-2 border-b-brumosa': style !== 'checkmark',
+      'border-b-0': noBottomBorder && style === 'icon',
     },
   );
 
@@ -69,7 +72,7 @@ export default function ListItem({
           alt={icon.alt ?? ''}
           height={icon.height}
           width={icon.width}
-          className="w-full h-auto"
+          className="h-auto w-full"
         />
       </div>
     ) : null,
@@ -89,8 +92,7 @@ export default function ListItem({
           <Link
             component={linkComponent}
             href={link.url}
-            className="mt-md text-h4 font-semibold"
-          >
+            className="mt-md text-h4 font-semibold">
             {link.title}
           </Link>
         )}

--- a/src/lib/components/02-components/list/list.stories.tsx
+++ b/src/lib/components/02-components/list/list.stories.tsx
@@ -46,3 +46,11 @@ export const Icon: Story = {
     )),
   },
 };
+
+export const IconWithoutBorder: Story = {
+  args: {
+    children: Array.from({ length: 3 }, (_, i) => (
+      <ListItem key={i} {...ListItemStories.IconWithoutBottomBorder.args} />
+    )),
+  },
+};


### PR DESCRIPTION
# Ticket(s)

- [FP-1130: USE CASE fix styles on custom 2-column](https://fourkitchens.clickup.com/t/36718269/FP-1130)

## Purpose

**This PR does the following:**

- CTA now has an option that will render text in place of button
- List item of type `icon` have the option to have no border bottom

### Functional Testing

- [ ] Visit new CTA story
- [ ] Visit new List story
