### PR TITLE
FP-1172: Fixes in form error messages styles

### DIFF
--- a/src/lib/assets/css/form.css
+++ b/src/lib/assets/css/form.css
@@ -38,6 +38,11 @@
   @apply text-azure !important;
 }
 
+/* Form field elements */
+.hs-form-field {
+  @apply relative;
+}
+
 /* Submit button styles */
 .hubspot-form-wrapper .hs_submit input {
   @apply cursor-pointer rounded-lg border-2 px-lg py-sm text-[1.0625rem] font-semibold;
@@ -197,5 +202,5 @@
 }
 
 label.hs-error-msg {
-  @apply relative right-0 rounded-m bg-crimson px-5 py-[10px] text-white;
+  @apply absolute right-0 z-10 mt-0 rounded-m bg-crimson px-5 py-[10px] text-white;
 }


### PR DESCRIPTION
# Ticket(s)

- [FP-1172: External Form - Multiple issues](https://fourkitchens.clickup.com/t/36718269/FP-1172)

## Purpose

- Improve form error message styles

### Pull Request Deployment

- Needed by https://github.com/fourkitchens/forcepoint-nextjs-page-router/pull/186

### Functional Testing

- [ ] Visit http://localhost:6006/?path=/story/components-form-textinput--input-with-error, confirm that the error message is absolutely positioned at the bottom right of the field container - **NOTE:** Story markup doesn't include the form wrapper element, which causes the field styles to be incomplete
