### PR TITLE
feat(1172): Make form color white when the form has a bg color

### DIFF
--- a/src/lib/assets/css/form.css
+++ b/src/lib/assets/css/form.css
@@ -34,7 +34,9 @@
 }
 
 .hubspot-form-wrapper-navy div:not([class]) p,
-.hubspot-form-wrapper-blue div:not([class]) p {
+.hubspot-form-wrapper-blue div:not([class]) p,
+.hubspot-form-wrapper-navy .hs-fieldtype-booleancheckbox .input label,
+.hubspot-form-wrapper-blue .hs-fieldtype-booleancheckbox .input label {
   @apply text-azure !important;
 }
 


### PR DESCRIPTION
# Ticket(s)

https://fourkitchens.clickup.com/t/36718269/FP-1172
### Functional Testing

- [ ] Go to a resource page on mobile
- [ ] All the text colors should be white
<img width="626" alt="Screenshot 2024-08-14 at 4 28 20 PM" src="https://github.com/user-attachments/assets/30f39879-73b2-4806-af7f-d5e1c29dbc6d">

Relates to https://github.com/fourkitchens/forcepoint-nextjs-page-router/pull/186