### PR TITLE
Add missing style on forms

### DIFF
--- a/src/lib/assets/css/form.css
+++ b/src/lib/assets/css/form.css
@@ -16,8 +16,13 @@
 .hubspot-form-wrapper .hs_jobtitle .input input,
 .hubspot-form-wrapper .hs_firstname .input input,
 .hubspot-form-wrapper .hs_lastname .input input,
+.hubspot-form-wrapper .hs-fieldtype-text .input input,
 .hubspot-form-wrapper .hs-fieldtype-select .input select {
   @apply block w-full rounded-m border border-brumosa px-5 py-3 text-grey outline-none focus:rounded-m focus:border-2 focus:border-teal focus:px-5 focus:py-3;
+}
+
+.hubspot-form-wrapper .hs-fieldtype-select .input select:disabled {
+  @apply text-brumosa;
 }
 
 /* Terms of use styles */

--- a/src/lib/assets/css/form.css
+++ b/src/lib/assets/css/form.css
@@ -22,7 +22,7 @@
 }
 
 .hubspot-form-wrapper .hs-fieldtype-select .input select.is-placeholder {
-  @apply text-brumosa;
+  @apply text-chateau;
 }
 
 /* Terms of use styles */

--- a/src/lib/assets/css/form.css
+++ b/src/lib/assets/css/form.css
@@ -21,7 +21,7 @@
   @apply block w-full rounded-m border border-brumosa px-5 py-3 text-grey outline-none focus:rounded-m focus:border-2 focus:border-teal focus:px-5 focus:py-3;
 }
 
-.hubspot-form-wrapper .hs-fieldtype-select .input select:disabled {
+.hubspot-form-wrapper .hs-fieldtype-select .input select.is-placeholder {
   @apply text-brumosa;
 }
 
@@ -125,6 +125,7 @@
 .hubspot-form-wrapper .hs_jobtitle .input,
 .hubspot-form-wrapper .hs_firstname .input,
 .hubspot-form-wrapper .hs_lastname .input,
+.hubspot-form-wrapper .hs-fieldtype-text  .input,
 .hubspot-form-wrapper .hs-fieldtype-select .input {
   @apply relative before:absolute before:left-sm before:top-[12px] before:block before:text-teal before:content-["*"];
 }


### PR DESCRIPTION
# Ticket(s)

- [Facebook Specific Form](https://app.asana.com/0/1203386530974194/1207990782653863/f)

## Purpose

**This PR does the following:**

- Fix select field in form
- Add text-field class

Before:
![Screenshot 2024-09-04 at 17 58 35](https://github.com/user-attachments/assets/ae0f4032-7eda-48d3-a1ad-ddc194f9eb01)

After:
![Screenshot 2024-09-04 at 17 57 12](https://github.com/user-attachments/assets/8d0fbd56-d4fd-4bc8-9dc4-47e1487f5371)


### Pull Request Deployment

- There might be a need to clear cache and rebuild to see the changes on the FE.

### Functional Testing

- [ ] run `npm install github:fourkitchens/forcepoint-shared-components#pull/143` locally
- [ ] visit /resources/industry-analyst-reports/forrester-securing-generative-ai-fb
- [ ] Add an email and click on Get you copy
